### PR TITLE
Update backend url and restart frontend

### DIFF
--- a/menu-frontend/src/app/add/page.js
+++ b/menu-frontend/src/app/add/page.js
@@ -7,7 +7,7 @@ import { useRouter } from "next/navigation";
  * Sends a POST request to create a new menu item.
  * @param {Object} data The menu item data to be sent.
  */
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "http://127.0.0.1:8000";
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "";
 
 async function createMenu(data) {
   const res = await fetch(`${API_BASE}/api/menu/`, {

--- a/menu-frontend/src/app/health/page.js
+++ b/menu-frontend/src/app/health/page.js
@@ -1,0 +1,4 @@
+export default function HealthPage() {
+  return new Response("ok");
+}
+

--- a/menu-frontend/src/app/page.js
+++ b/menu-frontend/src/app/page.js
@@ -7,7 +7,7 @@ import { useRouter, useSearchParams } from "next/navigation";
  * Fetches a menu item by ID.
  * @param {number} id The ID of the menu item to retrieve.
  */
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "http://127.0.0.1:8000";
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "";
 
 async function deleteMenu(id) {
   const res = await fetch(`${API_BASE}/api/menu/${id}/`, {

--- a/menu-frontend/src/app/update/[menuId]/page.js
+++ b/menu-frontend/src/app/update/[menuId]/page.js
@@ -7,7 +7,7 @@ import { useRouter } from "next/navigation";
  * Fetches a menu item by ID.
  * @param {number} id The ID of the menu item to retrieve.
  */
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "http://127.0.0.1:8000";
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "";
 
 async function getMenu(id) {
   const res = await fetch(`${API_BASE}/api/menu/${id}/`);


### PR DESCRIPTION
Update frontend to use relative API paths and add a health endpoint for ALB Ingress compatibility.

The previous `API_BASE` defaulted to `http://127.0.0.1:8000`, which caused issues when the frontend was served via an Ingress that also routed `/api` paths. By using a relative path, the frontend correctly calls `/api/...`, which the Ingress then routes to the backend service. The new `/health` endpoint ensures the ALB can successfully perform health checks on the frontend service, which is crucial for the Ingress to become available.

---
<a href="https://cursor.com/background-agent?bcId=bc-35afc86a-6b4f-41d7-8f6c-570dad845913">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-35afc86a-6b4f-41d7-8f6c-570dad845913">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

